### PR TITLE
Removed call to undefined property in PHP request class

### DIFF
--- a/php/pomsbundle/Request.php
+++ b/php/pomsbundle/Request.php
@@ -351,7 +351,7 @@ class Request {
 		} else {
 			$result = json_decode($dataResult, True);
 			if(!is_array($result)) {
-				throw new \Ntr\PomsBundle\Poms\Exception\InvalidResponseException('Response for URL: ' . $url . ': "'.$dataResult.'" is invalid JSON', $this->siteId);
+				throw new \Ntr\PomsBundle\Poms\Exception\InvalidResponseException('Response for URL: ' . $url . ': "'.$dataResult.'" is invalid JSON');
 			}
 		}
 		return $result;


### PR DESCRIPTION
`$this->siteId` is not defined anywhere in the example code.
